### PR TITLE
Terts' opinionated changes

### DIFF
--- a/src/layouts/HomeLayout.astro
+++ b/src/layouts/HomeLayout.astro
@@ -19,6 +19,7 @@ import Footer from "../components/footer.astro";
           <a href="/schedule" class="button button-primary">Schedule</a>
           <a href="/speakers" class="button button-secondary">Our speakers</a>
         </div>
+        <a class="down-arrow" href="#explainer"></a>
       </section>
       <section class="container md:grid md:cols-12">
         <div class="text-lg md:col-start-3 md:col-end-11 xl:col-start-4 xl:col-end-10">

--- a/src/layouts/HomeLayout.astro
+++ b/src/layouts/HomeLayout.astro
@@ -44,25 +44,25 @@ import Footer from "../components/footer.astro";
           <h3 class="text-xl text-center">Title 2023</h3>
           <div class="grid md:cols-2 xl:cols-4">
             <div class="benefit">
-              <div class="icon"></div>
+              <div class="icon rocket"></div>
               <div>
                 <strong>First edition</strong> in Amsterdam in 2023
               </div>
             </div>
             <div class="benefit">
-              <div class="icon"></div>
+              <div class="icon ticket"></div>
               <div>
                 <strong>Sold out</strong> 300 attendees
               </div>
             </div>
             <div class="benefit">
-              <div class="icon"></div>
+              <div class="icon eye"></div>
               <div>
                 <strong>100k</strong> Youtube views
               </div>
             </div>
             <div class="benefit">
-              <div class="icon"></div>
+              <div class="icon message"></div>
               <div>
                 <strong>Cool</strong> talks
               </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,7 +5,7 @@ import TimetableItem from "../components/timetable-item.astro";
 
 <HomeLayout>
     <div class="markdown" slot="explainer">
-        <h1>Rust what?</h1>
+        <h1 id="explainer">Rust what?</h1>
         <p>
             After our first edition in <a href="#last-year">Amsterdam</a> last year,
             we wanted more! After many more meetups, it's time for RustNL 2024, this

--- a/src/styles/components/_benefits.scss
+++ b/src/styles/components/_benefits.scss
@@ -18,11 +18,28 @@
 
   .icon {
     aspect-ratio: 1;
-    background-image: url('./images/icon/rocket.png');
+    
     background-position: center center;
     background-repeat: no-repeat;
     background-size: contain;
     background-size: contain;
     width: var(--space-24);
+
+    &.ticket {
+      background-image: url('./images/icon/ticket.png');
+    }
+
+    &.rocket {
+      background-image: url('./images/icon/rocket.png');
+    }
+    
+    &.eye {
+      background-image: url('./images/icon/eye.png');
+    }
+    
+    &.message {
+      background-image: url('./images/icon/message.png');
+    }
   }
+  
 }

--- a/src/styles/components/_buttons.scss
+++ b/src/styles/components/_buttons.scss
@@ -33,3 +33,21 @@
   border: 1px solid var(--color-red-400);
   color: var(--color-red-400);
 }
+
+.down-arrow {
+  border: solid var(--color-red-400);
+  border-width: 0 .5em .5em 0;
+  display: inline-block;
+  padding: .5em;
+  animation: MoveUpDown 2s ease-in-out infinite;
+}
+
+
+@keyframes MoveUpDown {
+  0%, 100% {
+    transform: translate(0, 0) rotate(45deg);
+  }
+  50% {
+    transform: translate(0, 0.4em) rotate(45deg);
+  }
+}

--- a/src/styles/components/_hero.scss
+++ b/src/styles/components/_hero.scss
@@ -3,9 +3,6 @@
 .hero {
   align-items: center;
   background-color: var(--color-yellow-400);
-  border-color: var(--color-neutral-400);
-  border-style: solid;
-  border-width: var(--space-4) var(--space-4) 0 var(--space-4);
   box-sizing: border-box;
   color: var(--color-neutral-400);
   display: flex;


### PR DESCRIPTION
Jonathan showed me this website yesterday, so I figured I'd help out a bit because I was bored and had some stuff to procrastinate.

I made the homepage look like this:

![image](https://github.com/rustnl/rustnl2024/assets/11643477/71c106e8-e9cb-4795-8c5c-c3f54b804a28)

With the border removed and an arrow with a little animation to indicate that people can scroll down.

The info about RustNL 2023 looks like this, which I figured was what you intended it to look like given the icons that are in the repository:

![image](https://github.com/rustnl/rustnl2024/assets/11643477/82d3b63b-41e7-4186-92fc-835a571dce92)

All the changes are in separate commits, so I can easily remove any changes from this PR if you want. Also feel free to just close this whole PR :)

Happy to help out some more if you give me some direction on what you want!