### PR TITLE
WIP: Workshop update tickets

### DIFF
--- a/src/components/workshop-detail.astro
+++ b/src/components/workshop-detail.astro
@@ -1,5 +1,5 @@
 ---
-const { title, time } = Astro.props;
+const { title, time, id } = Astro.props;
 ---
 
 <div class="markdown">
@@ -8,7 +8,7 @@ const { title, time } = Astro.props;
         <strong>
             {time}
         </strong>
-        <div class="space-y-6">
+        <div class="space-y-6" id={id}>
             <slot />
         </div>
     </div>

--- a/src/pages/workshops.astro
+++ b/src/pages/workshops.astro
@@ -10,6 +10,7 @@ import Trainer from "../components/trainer.astro";
         <WorkshopDetail
             title="Using `postcard` to talk to your Microcontroller"
             time="Tuesday (day 1) 09:00-13:00"
+            id="james"
         >
             <p>
                 This workshop is focused on setting up communications between a
@@ -82,6 +83,7 @@ import Trainer from "../components/trainer.astro";
         <WorkshopDetail
             title="Building UIs with Makepad"
             time="Tuesday (day 1) 14:00-17:30"
+            id="rik"
         >
             <p>
                 In this workshop we will use a small RiscV microcontroller
@@ -132,6 +134,7 @@ import Trainer from "../components/trainer.astro";
         <WorkshopDetail
             title="Mix-in-Rust"
             time="Wednesday (day 2) 09:00-13:00"
+            id="tim-and-henk"
         >
             <p>
                 Are you a happy Rust developer, who cannot wait but struggles to
@@ -180,6 +183,7 @@ import Trainer from "../components/trainer.astro";
         <WorkshopDetail
             title="Building debuggable applications—a tracing crate masterclass"
             time="Wednesday (day 2) 09:00-13:00"
+            id="luca"
         >
             <p>
                 Your Rust application has finally been deployed to production!

--- a/src/pages/workshops.astro
+++ b/src/pages/workshops.astro
@@ -9,7 +9,7 @@ import Trainer from "../components/trainer.astro";
         <!-- in the 'Chaos' building -->
         <WorkshopDetail
             title="Using `postcard` to talk to your Microcontroller"
-            time="Tuesday (day 1) 09:00"
+            time="Tuesday (day 1) 09:00-13:00"
         >
             <p>
                 This workshop is focused on setting up communications between a
@@ -57,7 +57,7 @@ import Trainer from "../components/trainer.astro";
         <!--  in the 'Experiment' building -->
         <WorkshopDetail
             title="Building UIs with Makepad"
-            time="Tuesday (day 1) 13:30"
+            time="Tuesday (day 1) 14:00-17:30"
         >
             <p>
                 In this workshop we will use a small RiscV microcontroller
@@ -105,7 +105,7 @@ import Trainer from "../components/trainer.astro";
 
     <div class="workshop">
         <!--  in the 'Chaos' building -->
-        <WorkshopDetail title="Mix-in-Rust" time="Wednesday (day 2) 09:00">
+        <WorkshopDetail title="Mix-in-Rust" time="Wednesday (day 2) 09:00-13:00">
             <p>
                 Are you a happy Rust developer, who cannot wait but struggles to
                 introduce Rust at their day job? Is the fear of working with
@@ -152,7 +152,7 @@ import Trainer from "../components/trainer.astro";
         <!-- in the 'Experiment' building -->
         <WorkshopDetail
             title="Building debuggable applications—a tracing crate masterclass"
-            time="Wednesday (day 2) 09:00"
+            time="Wednesday (day 2) 09:00-13:00"
         >
             <p>
                 Your Rust application has finally been deployed to production!

--- a/src/pages/workshops.astro
+++ b/src/pages/workshops.astro
@@ -51,6 +51,22 @@ import Trainer from "../components/trainer.astro";
                 github="github.com/jamesmunns"
             />
         </div>
+        <div class="space-y-3">
+            <h4 class="text-lg">Get your ticket!</h4>
+            <p>
+                - Conference incl workshop - Individual - € 498<br />
+                - Conference incl workshop - Employer-paid - € 750<br />
+                <br />
+                Goto <a href="">Conference incl workshop tickets</a>, and choose <strong>"Postcard"</strong> when checking out.<br />
+                <br />
+                <strong>Already have a ticket for the conference?</strong><br />
+                You'll need an additional workshop ticket.<br /><br /> 
+                - Workshop ticket - Individual - € 225<br />
+                - Workshop ticket - Employer-paid - € 300<br />
+                <br />
+                Goto <a href="">Workshop tickets</a>, and choose <strong>"Postcard"</strong> when checking out.<br />
+            </p>
+        </div>
     </div>
 
     <div class="workshop">

--- a/src/pages/workshops.astro
+++ b/src/pages/workshops.astro
@@ -59,9 +59,9 @@ import Trainer from "../components/trainer.astro";
                 - Conference incl workshop - Employer-paid - € 750<br />
                 <br />
                 Go to <a
-                    href="www.eventbrite.com/e/790061233417/?discount=postcard-workshop"
+                    href="https://www.eventbrite.com/e/rustnl-2024-tickets-790061233417"
                     >Conference incl workshop tickets</a
-                >, and choose <strong>"Postcard"</strong> when checking out.<br
+                >, and choose <strong>"Postcard"</strong> after checking out.<br
                 />
                 <br />
                 <strong>Already have a ticket for the conference?</strong><br />
@@ -72,7 +72,7 @@ import Trainer from "../components/trainer.astro";
                 Go to <a
                     href="www.eventbrite.com/e/790061233417/?discount=postcard-workshop"
                     >Workshop tickets</a
-                >, and choose <strong>"Postcard"</strong> when checking out.<br
+                >, and choose the <strong>"Postcard"</strong> workshop ticket.<br
                 />
             </p>
         </div>
@@ -127,6 +127,31 @@ import Trainer from "../components/trainer.astro";
                 github="https://github.com/makepad/makepad"
             />
         </div>
+
+        <div class="space-y-3">
+            <h4 class="text-lg">Get your ticket!</h4>
+            <p>
+                - Conference incl workshop - Individual - € 498<br />
+                - Conference incl workshop - Employer-paid - € 750<br />
+                <br />
+                Go to <a
+                    href="https://www.eventbrite.com/e/rustnl-2024-tickets-790061233417"
+                    >Conference incl workshop tickets</a
+                >, and choose <strong>"Makepad"</strong> after checking out.<br
+                />
+                <br />
+                <strong>Already have a ticket for the conference?</strong><br />
+                You'll need an additional workshop ticket.<br /><br />
+                - Workshop ticket - Individual - € 225<br />
+                - Workshop ticket - Employer-paid - € 300<br />
+                <br />
+                Go to <a
+                    href="www.eventbrite.com/e/790061233417/?discount=makepad-workshop"
+                    >Workshop tickets</a
+                >, and choose the <strong>"Makepad"</strong> workshop ticket.<br
+                />
+            </p>
+        </div>
     </div>
 
     <div class="workshop">
@@ -176,6 +201,31 @@ import Trainer from "../components/trainer.astro";
                 github="https://github.com/hdoordt/"
             />
         </div>
+
+        <div class="space-y-3">
+            <h4 class="text-lg">Get your ticket!</h4>
+            <p>
+                - Conference incl workshop - Individual - € 498<br />
+                - Conference incl workshop - Employer-paid - € 750<br />
+                <br />
+                Go to <a
+                    href="https://www.eventbrite.com/e/rustnl-2024-tickets-790061233417"
+                    >Conference incl workshop tickets</a
+                >, and choose <strong>"Mix-in Rust"</strong> after checking out.<br
+                />
+                <br />
+                <strong>Already have a ticket for the conference?</strong><br />
+                You'll need an additional workshop ticket.<br /><br />
+                - Workshop ticket - Individual - € 225<br />
+                - Workshop ticket - Employer-paid - € 300<br />
+                <br />
+                Go to <a
+                    href="www.eventbrite.com/e/790061233417/?discount=mix-in-rust-workshop"
+                    >Workshop tickets</a
+                >, and choose the <strong>"Mix-in Rust"</strong> workshop ticket.<br
+                />
+            </p>
+        </div>
     </div>
 
     <div class="workshop">
@@ -217,6 +267,30 @@ import Trainer from "../components/trainer.astro";
                 mastodon=""
                 github="https://github.com/LukeMathWalker"
             />
+        </div>
+        <div class="space-y-3">
+            <h4 class="text-lg">Get your ticket!</h4>
+            <p>
+                - Conference incl workshop - Individual - € 498<br />
+                - Conference incl workshop - Employer-paid - € 750<br />
+                <br />
+                Go to <a
+                    href="https://www.eventbrite.com/e/rustnl-2024-tickets-790061233417"
+                    >Conference incl workshop tickets</a
+                >, and choose <strong>"Tracing"</strong> after checking out.<br
+                />
+                <br />
+                <strong>Already have a ticket for the conference?</strong><br />
+                You'll need an additional workshop ticket.<br /><br />
+                - Workshop ticket - Individual - € 225<br />
+                - Workshop ticket - Employer-paid - € 300<br />
+                <br />
+                Go to <a
+                    href="www.eventbrite.com/e/790061233417/?discount=tracing-workshop"
+                    >Workshop tickets</a
+                >, and choose the <strong>"Tracing"</strong> workshop ticket.<br
+                />
+            </p>
         </div>
     </div>
 </WorkshopLayout>

--- a/src/pages/workshops.astro
+++ b/src/pages/workshops.astro
@@ -57,14 +57,22 @@ import Trainer from "../components/trainer.astro";
                 - Conference incl workshop - Individual - € 498<br />
                 - Conference incl workshop - Employer-paid - € 750<br />
                 <br />
-                Goto <a href="">Conference incl workshop tickets</a>, and choose <strong>"Postcard"</strong> when checking out.<br />
+                Go to <a
+                    href="www.eventbrite.com/e/790061233417/?discount=postcard-workshop"
+                    >Conference incl workshop tickets</a
+                >, and choose <strong>"Postcard"</strong> when checking out.<br
+                />
                 <br />
                 <strong>Already have a ticket for the conference?</strong><br />
-                You'll need an additional workshop ticket.<br /><br /> 
+                You'll need an additional workshop ticket.<br /><br />
                 - Workshop ticket - Individual - € 225<br />
                 - Workshop ticket - Employer-paid - € 300<br />
                 <br />
-                Goto <a href="">Workshop tickets</a>, and choose <strong>"Postcard"</strong> when checking out.<br />
+                Go to <a
+                    href="www.eventbrite.com/e/790061233417/?discount=postcard-workshop"
+                    >Workshop tickets</a
+                >, and choose <strong>"Postcard"</strong> when checking out.<br
+                />
             </p>
         </div>
     </div>
@@ -121,7 +129,10 @@ import Trainer from "../components/trainer.astro";
 
     <div class="workshop">
         <!--  in the 'Chaos' building -->
-        <WorkshopDetail title="Mix-in-Rust" time="Wednesday (day 2) 09:00-13:00">
+        <WorkshopDetail
+            title="Mix-in-Rust"
+            time="Wednesday (day 2) 09:00-13:00"
+        >
             <p>
                 Are you a happy Rust developer, who cannot wait but struggles to
                 introduce Rust at their day job? Is the fear of working with


### PR DESCRIPTION
Adds ticket information about workshop, incl guidance on how to buy a workshop ticket if you already have a conference ticket.

Todo:
- Do we want to present it in this way?
- Do we want to create an option to select the workshop? (or ask to add it in a description or remark field when checking out?)
- Todo: copy the ticket description to all workshops (component with title of the workshop)
- Todo: Add links to eventbrite, showing the options (if possible only the relevant options)

